### PR TITLE
Fix RangeError for addler32 or crc sums out of range.

### DIFF
--- a/lib/pr/zlib.rb
+++ b/lib/pr/zlib.rb
@@ -1513,7 +1513,7 @@ module Zlib
 
   def adler32(string=nil, adler=nil)
     if adler
-      [adler].pack('L')  # check range
+      check_long_range adler
       sum = adler
     elsif string.nil?
       sum = 0
@@ -1529,10 +1529,10 @@ module Zlib
     sum
   end
 
-  def crc32(string=nil, adler=nil)
-    if adler
-      [adler].pack('L') # check range
-      sum = adler
+  def crc32(string=nil, crc=nil)
+    if crc
+      check_long_range crc
+      sum = crc
     elsif string.nil?
       sum = 0
     else
@@ -1549,6 +1549,12 @@ module Zlib
 
   def crc_table
     get_crc_table
+  end
+
+  private
+
+  def self.check_long_range(num)
+    raise RangeError, 'bignum too big to convert into `unsigned long\'' if num.is_a? Bignum
   end
 
 end

--- a/lib/pr/zlib.rb
+++ b/lib/pr/zlib.rb
@@ -1553,8 +1553,12 @@ module Zlib
 
   private
 
+  LONG_MAX = 2**64 - 1
+  LONG_MIN = -2**63
+
   def self.check_long_range(num)
-    raise RangeError, 'bignum too big to convert into `unsigned long\'' if num.is_a? Bignum
+    # the error says 'unsigned', but this seems to be the range actually accepted
+    raise RangeError, 'bignum too big to convert into `unsigned long\'' if num < LONG_MIN || num > LONG_MAX
   end
 
 end

--- a/test/test_zlib.rb
+++ b/test/test_zlib.rb
@@ -92,6 +92,10 @@ class TC_Zlib < Test::Unit::TestCase
       assert_equal(73728451, Zlib.adler32('test', 3))
    end
 
+  def test_adler32_module_function_expected_errors
+    assert_raise(RangeError){ Zlib.adler32('test', 2**128) }
+  end
+
    def test_crc32_module_function_basic
       assert_respond_to(Zlib, :crc32)
       assert_nothing_raised{ Zlib.crc32 }
@@ -103,6 +107,10 @@ class TC_Zlib < Test::Unit::TestCase
       assert_equal(0, Zlib.crc32(nil, 3))
       assert_equal(3402289634, Zlib.crc32('test', 3))
    end
+
+  def test_crc32_module_function_expected_errors
+    assert_raise(RangeError){ Zlib.crc32('test', 2**128) }
+  end
 
    def test_crc_table_module_function_basic
       assert_respond_to(Zlib, :crc_table)


### PR DESCRIPTION
I don't know if the `pack('L')` method used to work, but it doesn't do what you think it does now on 2.2.3 - it just outputs the first four bytes of the `Bignum`.