### PR TITLE
GzipWriter defaults are set even if parameters are explicitly null.

### DIFF
--- a/lib/pr/zlib.rb
+++ b/lib/pr/zlib.rb
@@ -1072,7 +1072,10 @@ module Zlib
       GzipWriter.gzfile_s_open(filename, 'wb', level, strategy, &blk)
     end
 
-    def initialize(io, level=Z_DEFAULT_COMPRESSION, strategy=Z_DEFAULT_STRATEGY)
+    def initialize(io, level=nil, strategy=nil)
+      level = Z_DEFAULT_COMPRESSION if level.nil?
+      strategy = Z_DEFAULT_STRATEGY if strategy.nil?
+
       gzfile_new(DeflateFuncs, :gzfile_writer_end)
       @gz.level = level
 

--- a/test/test_zlib_gzip_writer.rb
+++ b/test/test_zlib_gzip_writer.rb
@@ -19,6 +19,8 @@ class TC_Zlib_GzipWriter < Test::Unit::TestCase
 
   def test_constructor
     assert_nothing_raised{ @writer = Zlib::GzipWriter.new(@handle) }
+    assert_nothing_raised{ @writer = Zlib::GzipWriter.new(@handle, nil) }
+    assert_nothing_raised{ @writer = Zlib::GzipWriter.new(@handle, nil, nil) }
   end
 
   def test_constructor_expected_errors


### PR DESCRIPTION
Bug exposed by running ActiveSupport's tests.