### PR TITLE
Zlib must always uses little endian instead of native endian

### DIFF
--- a/lib/pr/rbzlib.rb
+++ b/lib/pr/rbzlib.rb
@@ -241,19 +241,19 @@ module Rbzlib
     end
 
     def [](idx)
-      @buffer[(idx * 2) + @offset, 2].unpack('S').first
+      @buffer[(idx * 2) + @offset, 2].unpack('v').first
     end
 
     def []=(idx, val)
-      @buffer[(idx * 2) + @offset, 2] = [val].pack('S')
+      @buffer[(idx * 2) + @offset, 2] = [val].pack('v')
     end
 
     def get()
-      @buffer[@offset, 2].unpack('S').first
+      @buffer[@offset, 2].unpack('v').first
     end
 
     def set(val)
-      @buffer[@offset, 2] = [val].pack('S')
+      @buffer[@offset, 2] = [val].pack('v')
     end
   end
 
@@ -668,7 +668,7 @@ module Rbzlib
 
     s.z_err = Z_DATA_ERROR if (c == Z_EOF)
 
-    return (x.unpack('L').first)
+    return (x.unpack('v').first)
   end
 
   # Check the gzip header of a gz_stream opened for reading. Set the stream

--- a/lib/pr/zlib.rb
+++ b/lib/pr/zlib.rb
@@ -877,15 +877,15 @@ module Zlib
     end
 
     def gzfile_get16(src)
-      src.unpack('S').first
+      src.unpack('v').first
     end
 
     def gzfile_get32(src)
-      src.unpack('L').first
+      src.unpack('V').first
     end
 
     def gzfile_set32(n)
-      [n].pack('L')
+      [n].pack('V')
     end
 
     def gzfile_make_header


### PR DESCRIPTION
* Do not rely on native endian but specify it in pack/unpack directives.
* This was discovered on Solaris, where it behaved incorrectly due to being a big-endian platform.